### PR TITLE
Initial partially working C prototype

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,21 @@
+Language: Cpp
+BasedOnStyle: GNU
+SortIncludes:    false
+AllowShortIfStatementsOnASingleLine: false
+BreakBeforeBraces: Linux
+TabWidth:        4
+IndentWidth:     4
+ColumnLimit:     89
+SpaceBeforeParens:
+    ControlStatements
+SpacesInCStyleCastParentheses: false
+SpaceAfterCStyleCast: true
+IndentCaseLabels: true
+AlignAfterOpenBracket: DontAlign
+BinPackArguments: true
+BinPackParameters: true
+AlwaysBreakAfterReturnType: AllDefinitions
+
+# These are disabled for version 6 compatibility
+# StatementMacros: ["PyObject_HEAD"]
+# AlignConsecutiveMacros: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+
+all: ext
+
+ext: _vcztoolsmodule.c
+	CFLAGS="-std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-cast-function-type" \
+	       python3 setup.py build_ext --inplace
+
+clean:
+	rm -f *.so *.o tags
+	rm -fR build

--- a/_vcztoolsmodule.c
+++ b/_vcztoolsmodule.c
@@ -1,0 +1,528 @@
+
+#define PY_SSIZE_T_CLEAN
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+#include <Python.h>
+#include <stddef.h> /* for offsetof() */
+#include <numpy/arrayobject.h>
+
+#include "vcf_encoder.h"
+
+// clang-format off
+typedef struct {
+    PyObject_HEAD
+    vcz_variant_encoder_t *vcf_encoder;
+    PyObject *arrays;
+} VcfEncoder;
+// clang-format on
+
+static void
+handle_library_error(int err)
+{
+    // TODO generate string messages.
+    PyErr_Format(PyExc_ValueError, "Error occured: %d: ", err);
+}
+
+static FILE *
+make_file(PyObject *fileobj, const char *mode)
+{
+    FILE *ret = NULL;
+    FILE *file = NULL;
+    int fileobj_fd, new_fd;
+
+    fileobj_fd = PyObject_AsFileDescriptor(fileobj);
+    if (fileobj_fd == -1) {
+        goto out;
+    }
+    new_fd = dup(fileobj_fd);
+    if (new_fd == -1) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        goto out;
+    }
+    file = fdopen(new_fd, mode);
+    if (file == NULL) {
+        (void) close(new_fd);
+        PyErr_SetFromErrno(PyExc_OSError);
+        goto out;
+    }
+    ret = file;
+out:
+    return ret;
+}
+
+/*===================================================================
+ * VcfEncoder
+ *===================================================================
+ */
+
+static int
+VcfEncoder_check_state(VcfEncoder *self)
+{
+    int ret = -1;
+    if (self->vcf_encoder == NULL) {
+        PyErr_SetString(PyExc_SystemError, "VcfEncoder not initialised");
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+static void
+VcfEncoder_dealloc(VcfEncoder *self)
+{
+    if (self->vcf_encoder != NULL) {
+        vcz_variant_encoder_free(self->vcf_encoder);
+        PyMem_Free(self->vcf_encoder);
+        self->vcf_encoder = NULL;
+    }
+    Py_XDECREF(self->arrays);
+    Py_TYPE(self)->tp_free((PyObject *) self);
+}
+
+static int
+VcfEncoder_add_array(
+    VcfEncoder *self, const char *prefix, const char *name, PyArrayObject *array)
+{
+    int ret = -1;
+    PyObject *key = PyUnicode_FromFormat("%s%s", prefix, name);
+
+    if (array == NULL || key == NULL) {
+        goto out;
+    }
+    ret = PyDict_SetItem(self->arrays, key, (PyObject *) array);
+out:
+    Py_XDECREF(key);
+    return ret;
+}
+
+static int
+VcfEncoder_store_fixed_array(VcfEncoder *self, PyArrayObject *array, const char *name,
+    int type, int dimension, int num_variants)
+{
+    int ret = -1;
+    npy_intp *shape;
+
+    assert(PyArray_CheckExact(array));
+    if (!PyArray_CHKFLAGS(array, NPY_ARRAY_IN_ARRAY)) {
+        PyErr_SetString(PyExc_ValueError, "Array must have NPY_ARRAY_IN_ARRAY flags.");
+        goto out;
+    }
+    if (PyArray_NDIM(array) != dimension) {
+        PyErr_Format(PyExc_ValueError, "Array %s is of the wrong dimension", name);
+        goto out;
+    }
+    shape = PyArray_DIMS(array);
+    if (shape[0] != (npy_intp) num_variants) {
+        PyErr_Format(PyExc_ValueError,
+            "Array %s must have first dimension equal to number of variants", name);
+        goto out;
+    }
+    if (PyArray_DTYPE(array)->type_num != type) {
+        PyErr_Format(PyExc_ValueError, "Array %s is not of the correct type", name);
+        goto out;
+    }
+
+    if (VcfEncoder_add_array(self, "", name, array) != 0) {
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+static int
+VcfEncoder_init(VcfEncoder *self, PyObject *args, PyObject *kwds)
+{
+    int ret = -1;
+    static char *kwlist[]
+        = { "num_variants", "num_samples", "chrom", "pos", "id", "ref", "alt", NULL };
+    int num_variants, num_samples;
+    PyArrayObject *chrom = NULL;
+    PyArrayObject *pos = NULL;
+    PyArrayObject *id = NULL;
+    PyArrayObject *ref = NULL;
+    PyArrayObject *alt = NULL;
+    int err;
+
+    self->vcf_encoder = NULL;
+    self->arrays = NULL;
+    self->vcf_encoder = PyMem_Calloc(1, sizeof(*self->vcf_encoder));
+    self->arrays = PyDict_New();
+    if (self->vcf_encoder == NULL || self->arrays == NULL) {
+        PyErr_NoMemory();
+        goto out;
+    }
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "iiO!O!O!O!O!", kwlist, &num_variants,
+            &num_samples, &PyArray_Type, &chrom, &PyArray_Type, &pos, &PyArray_Type, &id,
+            &PyArray_Type, &ref, &PyArray_Type, &alt)) {
+        goto out;
+    }
+    if (VcfEncoder_store_fixed_array(self, chrom, "CHROM", NPY_STRING, 1, num_variants)
+        != 0) {
+        goto out;
+    }
+    if (VcfEncoder_store_fixed_array(self, pos, "POS", NPY_INT32, 1, num_variants)
+        != 0) {
+        goto out;
+    }
+    if (VcfEncoder_store_fixed_array(self, id, "ID", NPY_STRING, 2, num_variants) != 0) {
+        goto out;
+    }
+    if (VcfEncoder_store_fixed_array(self, ref, "REF", NPY_STRING, 1, num_variants)
+        != 0) {
+        goto out;
+    }
+    if (VcfEncoder_store_fixed_array(self, alt, "ALT", NPY_STRING, 2, num_variants)
+        != 0) {
+        goto out;
+    }
+
+    // clang-format off
+    err = vcz_variant_encoder_init(
+        self->vcf_encoder, num_samples, num_variants,
+        PyArray_DATA(chrom),
+        PyArray_ITEMSIZE(chrom), PyArray_DATA(pos),
+        PyArray_DATA(id), PyArray_ITEMSIZE(id), PyArray_DIMS(id)[1],
+        PyArray_DATA(ref), PyArray_ITEMSIZE(ref),
+        PyArray_DATA(alt), PyArray_ITEMSIZE(alt), PyArray_DIMS(alt)[1],
+        PyArray_DATA(pos),
+        PyArray_DATA(chrom), PyArray_ITEMSIZE(chrom), 1 // FIXME
+    );
+    // clang-format on
+    if (err < 0) {
+        handle_library_error(err);
+        goto out;
+    }
+
+    ret = 0;
+out:
+    return ret;
+}
+
+static int
+VcfEncoder_add_field_array(VcfEncoder *self, const char *name, PyArrayObject *array,
+    npy_intp dimension, const char *prefix)
+{
+    int ret = -1;
+    npy_intp *shape;
+
+    if (VcfEncoder_check_state(self) != 0) {
+        goto out;
+    }
+
+    assert(PyArray_CheckExact(array));
+    if (!PyArray_CHKFLAGS(array, NPY_ARRAY_IN_ARRAY)) {
+        PyErr_SetString(PyExc_ValueError, "Array must have NPY_ARRAY_IN_ARRAY flags.");
+        goto out;
+    }
+    if (PyArray_NDIM(array) != dimension) {
+        PyErr_SetString(PyExc_ValueError, "Array wrong dimension");
+        goto out;
+    }
+    shape = PyArray_DIMS(array);
+    if (shape[0] != (npy_intp) self->vcf_encoder->num_variants) {
+        PyErr_SetString(PyExc_ValueError,
+            "Array must have first dimension equal to number of variants");
+        goto out;
+    }
+
+    if (VcfEncoder_add_array(self, prefix, name, array) != 0) {
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+static int
+np_type_to_vcz_type(PyArrayObject *array)
+{
+    int ret = -1;
+
+    switch (PyArray_DTYPE(array)->kind) {
+        case 'i':
+            ret = VCZ_TYPE_INT;
+            break;
+        case 'S':
+            ret = VCZ_TYPE_STRING;
+            break;
+        default:
+            PyErr_SetString(PyExc_ValueError, "Unsupported array dtype");
+            goto out;
+    }
+out:
+    return ret;
+}
+
+static PyObject *
+VcfEncoder_add_info_field(VcfEncoder *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    PyArrayObject *array = NULL;
+    const char *name;
+    int err, type;
+
+    if (!PyArg_ParseTuple(args, "sO!", &name, &PyArray_Type, &array)) {
+        goto out;
+    }
+    if (VcfEncoder_add_field_array(self, name, array, 2, "INFO/") != 0) {
+        goto out;
+    }
+    type = np_type_to_vcz_type(array);
+    if (type < 0) {
+        goto out;
+    }
+    err = vcz_variant_encoder_add_info_field(self->vcf_encoder, name, type,
+        PyArray_ITEMSIZE(array), PyArray_DIMS(array)[1], PyArray_DATA(array));
+
+    if (err < 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
+static PyObject *
+VcfEncoder_add_format_field(VcfEncoder *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    PyArrayObject *array = NULL;
+    const char *name;
+    int err, type;
+
+    if (!PyArg_ParseTuple(args, "sO!", &name, &PyArray_Type, &array)) {
+        goto out;
+    }
+    if (VcfEncoder_add_field_array(self, name, array, 3, "FORMAT/") != 0) {
+        goto out;
+    }
+    type = np_type_to_vcz_type(array);
+    if (type < 0) {
+        goto out;
+    }
+    err = vcz_variant_encoder_add_format_field(self->vcf_encoder, name, type,
+        PyArray_ITEMSIZE(array), PyArray_DIMS(array)[2], PyArray_DATA(array));
+    if (err < 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
+static PyObject *
+VcfEncoder_add_gt_field(VcfEncoder *self, PyObject *args)
+{
+    PyArrayObject *gt = NULL;
+    PyArrayObject *gt_phased = NULL;
+    PyArrayObject *array;
+    PyObject *ret = NULL;
+    int err;
+    npy_intp *shape;
+
+    if (VcfEncoder_check_state(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTuple(args, "O!O!", &PyArray_Type, &gt, &PyArray_Type, &gt_phased)) {
+        goto out;
+    }
+
+    array = gt;
+    assert(PyArray_CheckExact(array));
+    if (!PyArray_CHKFLAGS(array, NPY_ARRAY_IN_ARRAY)) {
+        PyErr_SetString(PyExc_ValueError, "Array must have NPY_ARRAY_IN_ARRAY flags.");
+        goto out;
+    }
+    if (PyArray_NDIM(array) != 3) {
+        PyErr_SetString(PyExc_ValueError, "Array wrong dimension");
+        goto out;
+    }
+    shape = PyArray_DIMS(array);
+    if (shape[0] != (npy_intp) self->vcf_encoder->num_variants) {
+        PyErr_SetString(PyExc_ValueError,
+            "Array must have first dimension equal to number of variants");
+        goto out;
+    }
+
+    if (VcfEncoder_add_array(self, "FORMAT/", "GT", array) != 0) {
+        goto out;
+    }
+
+    array = gt_phased;
+    assert(PyArray_CheckExact(array));
+    if (!PyArray_CHKFLAGS(array, NPY_ARRAY_IN_ARRAY)) {
+        PyErr_SetString(PyExc_ValueError, "Array must have NPY_ARRAY_IN_ARRAY flags.");
+        goto out;
+    }
+    if (PyArray_NDIM(array) != 2) {
+        PyErr_SetString(PyExc_ValueError, "Array wrong dimension");
+        goto out;
+    }
+    shape = PyArray_DIMS(array);
+    if (shape[0] != (npy_intp) self->vcf_encoder->num_variants) {
+        PyErr_SetString(PyExc_ValueError,
+            "Array must have first dimension equal to number of variants");
+        goto out;
+    }
+    if (VcfEncoder_add_array(self, "FORMAT/", "GT_phased", array) != 0) {
+        goto out;
+    }
+    err = vcz_variant_encoder_add_gt_field(self->vcf_encoder, PyArray_DATA(gt),
+        PyArray_ITEMSIZE(gt), PyArray_DIMS(gt)[2], PyArray_DATA(gt_phased));
+    if (err != 0) {
+        goto out;
+    }
+
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
+static PyObject *
+VcfEncoder_encode_row(VcfEncoder *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    int row;
+    int bufsize;
+    char *buf = NULL;
+    int64_t line_length;
+
+    if (VcfEncoder_check_state(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTuple(args, "ii", &row, &bufsize)) {
+        goto out;
+    }
+    buf = PyMem_Malloc(bufsize);
+    if (buf == NULL) {
+        goto out;
+    }
+    line_length = vcz_variant_encoder_write_row(self->vcf_encoder, row, buf, bufsize);
+    if (line_length < 0) {
+        handle_library_error((int) line_length);
+        goto out;
+    }
+    ret = Py_BuildValue("s#", buf, line_length);
+out:
+    PyMem_Free(buf);
+    return ret;
+}
+
+static PyObject *
+VcfEncoder_print_state(VcfEncoder *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    PyObject *fileobj;
+    FILE *file = NULL;
+
+    if (VcfEncoder_check_state(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTuple(args, "O", &fileobj)) {
+        goto out;
+    }
+    file = make_file(fileobj, "w");
+    if (file == NULL) {
+        goto out;
+    }
+    vcz_variant_encoder_print_state(self->vcf_encoder, file);
+    ret = Py_BuildValue("");
+out:
+    if (file != NULL) {
+        (void) fclose(file);
+    }
+    return ret;
+}
+
+/* Return a copy of the dictionary of arrays providing the memory backing.
+ * Note that we return copy of the Dictionary here so that the arrays themselves
+ * can't be removed from it.
+ */
+static PyObject *
+VcfEncoder_getarrays(VcfEncoder *self, void *closure)
+{
+    return PyDict_Copy(self->arrays);
+}
+
+static PyGetSetDef VcfEncoder_getsetters[] = {
+    { "arrays", (getter) VcfEncoder_getarrays, NULL, "Arrays used for memory backing",
+        NULL },
+    { NULL } /* Sentinel */
+};
+
+static PyMethodDef VcfEncoder_methods[] = {
+    { .ml_name = "print_state",
+        .ml_meth = (PyCFunction) VcfEncoder_print_state,
+        .ml_flags = METH_VARARGS,
+        .ml_doc = "Debug method to print out the low-level state" },
+    { .ml_name = "add_info_field",
+        .ml_meth = (PyCFunction) VcfEncoder_add_info_field,
+        .ml_flags = METH_VARARGS,
+        .ml_doc = "Add an INFO field to the encoder" },
+    { .ml_name = "add_gt_field",
+        .ml_meth = (PyCFunction) VcfEncoder_add_gt_field,
+        .ml_flags = METH_VARARGS,
+        .ml_doc = "Add the GT field" },
+    { .ml_name = "add_format_field",
+        .ml_meth = (PyCFunction) VcfEncoder_add_format_field,
+        .ml_flags = METH_VARARGS,
+        .ml_doc = "Add a format field to the encoder" },
+    { .ml_name = "encode_row",
+        .ml_meth = (PyCFunction) VcfEncoder_encode_row,
+        .ml_flags = METH_VARARGS,
+        .ml_doc = "Return the specified row of VCF text" },
+    { NULL } /* Sentinel */
+};
+
+static PyTypeObject VcfEncoderType = {
+    // clang-format off
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "_vcztools.VcfEncoder",
+    .tp_basicsize = sizeof(VcfEncoder),
+    .tp_dealloc = (destructor) VcfEncoder_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "VcfEncoder objects",
+    .tp_methods = VcfEncoder_methods,
+    .tp_init = (initproc) VcfEncoder_init,
+    .tp_new = PyType_GenericNew,
+    .tp_getset = VcfEncoder_getsetters,
+    // clang-format on
+};
+
+/*===================================================================
+ * Module level code.
+ *===================================================================
+ */
+
+static PyMethodDef vcztools_methods[] = {
+    { NULL } /* Sentinel */
+};
+
+static struct PyModuleDef vcztoolsmodule = { PyModuleDef_HEAD_INIT, "_vcztools",
+    "C interface for vcztools.", -1, vcztools_methods, NULL, NULL, NULL, NULL };
+
+PyObject *
+PyInit__vcztools(void)
+{
+    PyObject *module = PyModule_Create(&vcztoolsmodule);
+
+    if (module == NULL) {
+        return NULL;
+    }
+    /* Initialise numpy */
+    import_array();
+
+    /* VcfEncoder type */
+    if (PyType_Ready(&VcfEncoderType) < 0) {
+        return NULL;
+    }
+    Py_INCREF(&VcfEncoderType);
+    PyModule_AddObject(module, "VcfEncoder", (PyObject *) &VcfEncoderType);
+
+    return module;
+}

--- a/dev.py
+++ b/dev.py
@@ -1,0 +1,163 @@
+import zarr
+import numcodecs
+import sys
+
+import _vcztools
+
+# From VCF fixed fields
+RESERVED_VARIABLE_NAMES = [
+    "variant_contig",
+    "variant_position",
+    "variant_id",
+    "variant_id_mask",
+    "variant_allele",
+    "variant_quality",
+    "variant_filter",
+]
+
+
+def copy_to_memory(group):
+    mem_group = zarr.group()
+    for name, array in group.items():
+        if array.dtype == "O":
+            copy = mem_group.empty_like(name, array, compressor={})
+            # FIXME: this is the best I've been able to come up with here.
+            # Something very weird with object arrays in v2
+            for j, row in enumerate(array):
+                copy[j] = row
+        else:
+            copy = mem_group.empty_like(name, array, compressor={})
+            copy[:] = array[:]
+        # print("copy = ", copy[:])
+    return mem_group
+
+
+def main(root):
+    v_chunk = 0
+    contigs = root["contig_id"][:].astype("S")
+    filters = root["filter_id"][:].astype("S")
+    # print("contigs = ", contigs)
+    # print("filters = ", contigs)
+
+    chrom = contigs[root.variant_contig.blocks[v_chunk]]
+    pos = root.variant_position.blocks[v_chunk]
+    id = root.variant_id.blocks[v_chunk].astype("S")
+    alleles = root.variant_allele.blocks[v_chunk]
+    ref = alleles[:, 0].astype("S")
+    alt = alleles[:, 1:].astype("S")
+    qual = root.variant_quality.blocks[v_chunk]
+    # filter_ = filters[root.variant_filter.blocks[v_chunk]]
+
+    num_variants = len(pos)
+    if len(id.shape) == 1:
+        id = id.reshape((num_variants, 1))
+
+    # TODO gathering fields and doing IO will be done separately later so that
+    # we avoid retrieving stuff we don't need.
+    format_fields = {}
+    info_fields = {}
+    for name, array in root.items():
+        if name.startswith("call_") and not name.startswith("call_genotype"):
+            vcf_name = name[len("call_") :]
+            format_fields[vcf_name] = array.blocks[v_chunk]
+        elif name.startswith("variant_") and name not in RESERVED_VARIABLE_NAMES:
+            vcf_name = name[len("variant_") :]
+            info_fields[vcf_name] = array.blocks[v_chunk]
+
+    gt = None
+    gt_phased = None
+    if "call_genotype" in root:
+        array = root["call_genotype"]
+        gt = array.blocks[v_chunk]
+        if "call_genotype_phased" in root:
+            array = root["call_genotype_phased"]
+            gt_phased = array.blocks[v_chunk]
+        else:
+            gt_phased = np.zeros_like(gt, dtype=bool)
+
+    # print(gt, gt_phased)
+    # print(list(format_fields.keys()))
+    # print(list(info_fields.keys()))
+
+    # print(contigs[chrom])
+    # print(bytes(contigs[chrom]))
+    # print(pos)
+    # print(alleles)
+    # print(alleles.dtype)
+    # print(chrom)
+    # print(pos)
+    # print(id)
+    # print(ref)
+    # print(alt)
+
+    num_samples = 0
+    if gt is not None:
+        num_samples = gt.shape[1]
+
+    encoder = _vcztools.VcfEncoder(
+        num_variants, num_samples, chrom=chrom, pos=pos, id=id, alt=alt, ref=ref
+    )
+    print(gt.shape)
+    print(gt_phased.shape)
+    encoder.add_gt_field(gt.astype("int32"), gt_phased)
+    # # print(encoder.arrays)
+    # # print(encoder)
+    for name, array in info_fields.items():
+        if array.dtype.kind == "O":
+            array = array.astype("S")
+        if len(array.shape) == 1:
+            array = array.reshape((num_variants, 1))
+        if array.dtype.kind == "i":
+            array = array.astype("int32")  # tmp
+        if array.dtype.kind == "f":
+            continue  # tmp
+        if array.dtype.kind == "b":
+            continue  # tmp
+            # array = array.astype("int32") # tmp
+
+        print(name, array.dtype, array.dtype.kind)
+        encoder.add_info_field(name, array)
+
+    for name, array in format_fields.items():
+        if array.dtype.kind == "O":
+            array = array.astype("S")
+        if len(array.shape) == 2:
+            array = array.reshape((num_variants, num_samples, 1))
+        if array.dtype.kind == "i":
+            array = array.astype("int32")  # tmp
+        if array.dtype.kind == "f":
+            continue  # tmp
+            # array = array.astype("int32") # tmp
+
+        print(name, array.dtype, array.dtype.kind)
+        encoder.add_format_field(name, array)
+
+    d = encoder.arrays
+    # pos = encoder.arrays["POS"]
+    # print(pos)
+    # # print(d)
+    # pos[0] = 123457
+    # print(pos.flags)
+    # pos.resize(0, refcheck=False)
+    # print(pos)
+
+    encoder.print_state(sys.stdout)
+    for k, v in encoder.arrays.items():
+        print(k, "\t", v.shape)
+    for j in range(num_variants):
+        line = encoder.encode_row(j, 2**30)
+        print(line)
+
+
+
+if __name__ == "__main__":
+    root = zarr.open(sys.argv[1], mode="r")
+    # root = copy_to_memory(root)
+    # print("pos = ", root["variant_position"].info)
+    # print(root.tree())
+    main(root)
+    # for _ in range(10000):
+    # import tqdm
+
+    # for _ in tqdm.tqdm(range(10000)):
+    #     main(root)

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,0 +1,24 @@
+project('vcf_encoder', ['c'],
+    default_options: ['c_std=c99']
+)
+
+cc = meson.get_compiler('c')
+m_dep = cc.find_library('m', required: false)
+lib_deps = [m_dep]
+
+extra_c_args = [
+    '-Wall', '-Wextra', '-Werror', '-Wpedantic', '-W',
+    '-Wmissing-prototypes',  '-Wstrict-prototypes',
+    '-Wconversion', '-Wshadow', '-Wpointer-arith', '-Wcast-align',
+    '-Wcast-qual', '-Wwrite-strings', '-Wnested-externs',
+    '-fshort-enums', '-fno-common']
+
+lib_sources = ['vcf_encoder.c']
+lib_headers = ['vcf_encoder.h']
+
+cunit_dep = dependency('cunit')
+
+tests = executable('tests',
+    sources: ['tests.c', 'vcf_encoder.c'],
+    dependencies: cunit_dep,
+  )

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -1,0 +1,278 @@
+#define _GNU_SOURCE
+#include <CUnit/Basic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <vcf_encoder.h>
+
+FILE *_devnull;
+
+static void
+test_int_field_1d(void)
+{
+    const int num_rows = 5;
+    const int32_t data[] = { 1, 2, 12345789, -1, -100 };
+    vcz_field_t field = { .name = "test",
+        .type = VCZ_TYPE_INT,
+        .item_size = 4,
+        .num_columns = 1,
+        .data = data };
+    char buf[1000];
+    const char *expected[] = { "1\t", "2\t", "12345789\t", ".\t", "-100\t" };
+    int ret;
+    size_t j;
+
+    for (j = 0; j < num_rows; j++) {
+        ret = vcz_field_write(&field, j, buf, 1000, 0);
+        /* printf("%s: %s\n", buf, expected[j]); */
+        CU_ASSERT_EQUAL_FATAL(ret, strlen(expected[j]));
+        CU_ASSERT_STRING_EQUAL(buf, expected[j]);
+    }
+}
+
+static void
+test_int_field_2d(void)
+{
+    const int num_rows = 4;
+    const int32_t data[] = { 1, 2, 3, 1234, 5678, -2, -1, -2, -2, -2, -2, -2 };
+    vcz_field_t field = { .name = "test",
+        .type = VCZ_TYPE_INT,
+        .item_size = 4,
+        .num_columns = 3,
+        .data = data };
+    char buf[1000];
+    const char *expected[] = { "1,2,3\t", "1234,5678\t", ".\t", "\t" };
+    int ret;
+    size_t j;
+
+    for (j = 0; j < num_rows; j++) {
+        ret = vcz_field_write(&field, j, buf, 1000, 0);
+        CU_ASSERT_EQUAL_FATAL(ret, strlen(expected[j]));
+        /* printf("%s: %s\n", buf, expected[j]); */
+        CU_ASSERT_STRING_EQUAL(buf, expected[j]);
+    }
+}
+
+static void
+test_string_field_1d(void)
+{
+    /* item_size=3, rows=3, cols=1 */
+    const int num_rows = 3;
+    const char data[] = "X\0\0" /* X */
+                        "XX\0"  /* XX*/
+                        "XXX";  /* XXX, */
+
+    vcz_field_t field = { .name = "test",
+        .type = VCZ_TYPE_STRING,
+        .item_size = 3,
+        .num_columns = 1,
+        .data = data };
+    char buf[1000];
+    const char *expected[] = { "X\t", "XX\t", "XXX\t" };
+    int ret;
+    size_t j;
+
+    CU_ASSERT_EQUAL_FATAL(sizeof(data), 10);
+    for (j = 0; j < num_rows; j++) {
+        ret = vcz_field_write(&field, j, buf, 1000, 0);
+        CU_ASSERT_EQUAL_FATAL(ret, strlen(expected[j]));
+        CU_ASSERT_STRING_EQUAL(buf, expected[j]);
+    }
+}
+
+static void
+test_string_field_2d(void)
+{
+    /* item_size=3, rows=3, cols=3 */
+    const int num_rows = 3;
+    const char data[] = "X\0\0Y\0\0\0\0\0" /* [X, Y] */
+                        "XX\0YY\0Z\0\0"    /* [XX, YY, Z], */
+                        "XXX\0\0\0\0\0";   /* [XXX], */
+
+    vcz_field_t field = { .name = "test",
+        .type = VCZ_TYPE_STRING,
+        .item_size = 3,
+        .num_columns = 3,
+        .data = data };
+    char buf[1000];
+    const char *expected[] = { "X,Y\t", "XX,YY,Z\t", "XXX\t" };
+    int ret;
+    size_t j;
+
+    CU_ASSERT_EQUAL_FATAL(sizeof(data), 27);
+
+    for (j = 0; j < num_rows; j++) {
+        ret = vcz_field_write(&field, j, buf, 1000, 0);
+        CU_ASSERT_EQUAL_FATAL(ret, strlen(expected[j]));
+        CU_ASSERT_STRING_EQUAL(buf, expected[j]);
+    }
+}
+
+static void
+test_variant_encoder_minimal(void)
+{
+    // Two rows, one column in each field, two samples
+    const int num_rows = 2;
+    const char contig_data[] = "X\0YY";
+    const int32_t pos_data[] = { 123, 45678 };
+    const char id_data[] = "RS1RS2";
+    const char ref_data[] = "AG";
+    const char alt_data[] = "TC";
+    const int32_t qual_data[] = { 1000, 12 };
+    const char filter_data[] = "PASSPASS";
+    const int32_t an_data[] = { 8, 9 };
+    const char* aa_data = "GT";
+    const int32_t gt_data[] = { 0, 0, 0, 1, 1, 1, 1, 0 };
+    const int8_t gt_phased_data[] = { 0, 1, 1, 0 };
+    const int32_t hq_data[] = { 10, 15, 7, 12, 8, 9, 10, 11 };
+    int ret, j;
+    vcz_variant_encoder_t writer;
+    const char *expected[] = {
+        "X\t123\tRS1\tA\tT\t1000\tPASS\tAN=8;AA=G\tFORMAT=GT:HQ\t0/0:10,15\t0|1:7,12",
+        "YY\t45678\tRS2\tG\tC\t12\tPASS\tAN=9;AA=T\tFORMAT=GT:HQ\t1|1:8,9\t1/0:10,11",
+    };
+    char buf[1000];
+
+    ret = vcz_variant_encoder_init(&writer, 2, 2, contig_data, 2, pos_data, id_data, 3,
+        1, ref_data, 1, alt_data, 1, 1, qual_data, filter_data, 4, 1);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = vcz_variant_encoder_add_gt_field(&writer, gt_data, 4, 2, gt_phased_data);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = vcz_variant_encoder_add_info_field(&writer, "AN", VCZ_TYPE_INT, 4, 1, an_data);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = vcz_variant_encoder_add_info_field(&writer, "AA", VCZ_TYPE_STRING, 1, 1, aa_data);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = vcz_variant_encoder_add_format_field(
+        &writer, "HQ", VCZ_TYPE_INT, 4, 2, hq_data);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    printf("\n");
+    vcz_variant_encoder_print_state(&writer, _devnull);
+    vcz_variant_encoder_print_state(&writer, stdout);
+
+    for (j = 0; j < num_rows; j++) {
+        ret = vcz_variant_encoder_write_row(&writer, j, buf, 1000);
+        printf("GOT:%s\n", buf);
+        printf("EXP:%s\n", expected[j]);
+        printf("GOT:%d\n", (int) strlen(buf));
+        printf("EXP:%d\n", (int) strlen(expected[j]));
+        CU_ASSERT_EQUAL(ret, strlen(expected[j]));
+        CU_ASSERT_STRING_EQUAL(buf, expected[j]);
+    }
+    vcz_variant_encoder_free(&writer);
+}
+
+// TODO also do this with larger values to hit all cases.
+static void
+test_itoa_small(void)
+{
+    char dest1[64], dest2[64];
+    int len1, len2;
+    int32_t j;
+
+    for (j = -255; j <= 256; j++) {
+        len1 = sprintf(dest1, "%d", j);
+        len2 = vcz_itoa(j, dest2);
+        /* printf("%s %s\n", dest1, dest2); */
+        CU_ASSERT_STRING_EQUAL(dest1, dest2);
+        CU_ASSERT_EQUAL(len1, len2);
+    }
+}
+
+/*=================================================
+  Test suite management
+  =================================================
+*/
+
+static int
+vcz_suite_init(void)
+{
+    _devnull = fopen("/dev/null", "w");
+    if (_devnull == NULL) {
+        return CUE_SINIT_FAILED;
+    }
+    return CUE_SUCCESS;
+}
+
+static int
+vcz_suite_cleanup(void)
+{
+    if (_devnull != NULL) {
+        fclose(_devnull);
+    }
+    return CUE_SUCCESS;
+}
+
+static void
+handle_cunit_error(void)
+{
+    fprintf(stderr, "CUnit error occured: %d: %s\n", CU_get_error(), CU_get_error_msg());
+    exit(EXIT_FAILURE);
+}
+
+int
+test_main(CU_TestInfo *tests, int argc, char **argv)
+{
+    int ret;
+    CU_pTest test;
+    CU_pSuite suite;
+    CU_SuiteInfo suites[] = {
+        {
+            .pName = "vcz",
+            .pTests = tests,
+            .pInitFunc = vcz_suite_init,
+            .pCleanupFunc = vcz_suite_cleanup,
+        },
+        CU_SUITE_INFO_NULL,
+    };
+    if (CUE_SUCCESS != CU_initialize_registry()) {
+        handle_cunit_error();
+    }
+    if (CUE_SUCCESS != CU_register_suites(suites)) {
+        handle_cunit_error();
+    }
+    CU_basic_set_mode(CU_BRM_VERBOSE);
+
+    if (argc == 1) {
+        CU_basic_run_tests();
+    } else if (argc == 2) {
+        suite = CU_get_suite_by_name("vcz", CU_get_registry());
+        if (suite == NULL) {
+            printf("Suite not found\n");
+            return EXIT_FAILURE;
+        }
+        test = CU_get_test_by_name(argv[1], suite);
+        if (test == NULL) {
+            printf("Test '%s' not found\n", argv[1]);
+            return EXIT_FAILURE;
+        }
+        CU_basic_run_test(suite, test);
+    } else {
+        printf("usage: %s <test_name>\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    ret = EXIT_SUCCESS;
+    if (CU_get_number_of_tests_failed() != 0) {
+        printf("Test failed!\n");
+        ret = EXIT_FAILURE;
+    }
+    CU_cleanup_registry();
+    return ret;
+}
+
+int
+main(int argc, char **argv)
+{
+    CU_TestInfo tests[] = {
+        { "test_string_field_1d", test_string_field_1d },
+        { "test_string_field_2d", test_string_field_2d },
+        { "test_int_field_1d", test_int_field_1d },
+        { "test_int_field_2d", test_int_field_2d },
+        { "test_variant_encoder_minimal", test_variant_encoder_minimal },
+        { "test_itoa_small", test_itoa_small },
+        { NULL, NULL },
+    };
+    return test_main(tests, argc, argv);
+}

--- a/lib/vcf_encoder.c
+++ b/lib/vcf_encoder.c
@@ -1,0 +1,501 @@
+#include "vcf_encoder.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+int
+vcz_itoa(int32_t value, char *buf)
+{
+    int p = 0;
+    int j, k;
+
+    if (value < 0) {
+        buf[p] = '-';
+        p++;
+        value = -value;
+    }
+    /*  special case small values */
+    if (value < 10) {
+        buf[p] = value + '0';
+        p++;
+    } else {
+        k = 0;
+        if (value < 100) {
+            k = 1;
+        } else if (value < 1000) {
+            k = 2;
+        } else if (value < 10000) {
+            k = 3;
+        } else if (value < 100000) {
+            k = 4;
+        } else if (value < 1000000) {
+            k = 5;
+        } else if (value < 10000000) {
+            k = 6;
+        } else if (value < 100000000) {
+            k = 7;
+        } else if (value < 1000000000) {
+            k = 8;
+        }
+
+        // iterate backwards in buf
+        p += k;
+        buf[p] = (value % 10) + '0';
+        for (j = 0; j < k; j++) {
+            p--;
+            value = value / 10;
+            buf[p] = (value % 10) + '0';
+        }
+        p += k + 1;
+    }
+    buf[p] = '\0';
+    return p;
+}
+
+static int64_t
+string_field_write_entry(
+    const vcz_field_t *self, const void *data, char *dest, size_t buflen, int64_t offset)
+{
+    const char *source = (char *) data;
+    size_t column, byte;
+    const char sep = ',';
+    int64_t source_offset = 0;
+
+    for (column = 0; column < self->num_columns; column++) {
+        if (column > 0 && source[source_offset] != '\0') {
+            dest[offset] = sep;
+            offset++;
+        }
+        for (byte = 0; byte < self->item_size; byte++) {
+            if (source[source_offset] != '\0') {
+                dest[offset] = source[source_offset];
+                offset++;
+            }
+            source_offset++;
+        }
+    }
+    dest[offset] = '\t';
+    offset++;
+    dest[offset] = '\0';
+    return offset;
+}
+
+static int64_t
+int32_field_write_entry(
+    const vcz_field_t *self, const void *data, char *dest, size_t buflen, int64_t offset)
+{
+    const int32_t *source = (int32_t *) data;
+    int32_t value;
+    size_t column;
+    /* int written; */
+    /* char value_buffer[128]; */
+
+    for (column = 0; column < self->num_columns; column++) {
+        value = source[column];
+        if (value != VCZ_INT_FILL) {
+            if (column > 0) {
+                dest[offset] = ',';
+                offset++;
+            }
+            if (value == VCZ_INT_MISSING) {
+                dest[offset] = '.';
+                offset++;
+            } else {
+                offset += vcz_itoa(value, dest + offset);
+                /* written = snprintf(value_buffer, sizeof(value_buffer), "%d", value);
+                 */
+                /* memcpy(dest + offset, value_buffer, written); */
+                /* offset += written; */
+            }
+        }
+    }
+    dest[offset] = '\t';
+    offset++;
+    dest[offset] = '\0';
+    return offset;
+}
+
+int64_t
+vcz_field_write_entry(
+    const vcz_field_t *self, const void *data, char *dest, size_t buflen, int64_t offset)
+{
+
+    if (self->type == VCZ_TYPE_INT) {
+        if (self->item_size == 4) {
+            return int32_field_write_entry(self, data, dest, buflen, offset);
+        }
+    } else if (self->type == VCZ_TYPE_STRING) {
+        return string_field_write_entry(self, data, dest, buflen, offset);
+    }
+    return VCZ_ERR_FIELD_UNSUPPORTED_TYPE;
+}
+
+int64_t
+vcz_field_write(
+    const vcz_field_t *self, size_t variant, char *dest, size_t buflen, int64_t offset)
+{
+
+    size_t row_size = self->num_columns * self->item_size;
+    const void *data = self->data + variant * row_size;
+
+    return vcz_field_write_entry(self, data, dest, buflen, offset);
+}
+
+void
+vcz_field_print_state(const vcz_field_t *self, FILE *out)
+{
+    fprintf(out, "\t%s\ttype:%d\titem_size=%d\tnum_columns=%d\tdata=%p\n", self->name,
+        self->type, (int) self->item_size, (int) self->num_columns, self->data);
+}
+
+int64_t
+vcz_variant_encoder_write_format_specifiers(
+    const vcz_variant_encoder_t *self, char *dest, size_t buflen, int64_t offset)
+{
+    const int format_len = 7;
+    size_t j;
+
+    strcpy(dest + offset, "FORMAT=");
+    offset += format_len;
+    if (self->gt.data != NULL) {
+        strcpy(dest + offset, "GT");
+        offset += 2;
+    }
+    for (j = 0; j < self->num_format_fields; j++) {
+        dest[offset] = ':';
+        offset++;
+        strcpy(dest + offset, self->format_fields[j].name);
+        offset += strlen(self->format_fields[j].name);
+    }
+    dest[offset] = '\t';
+    offset++;
+    dest[offset] = '\0';
+    return offset;
+}
+
+int64_t
+vcz_variant_encoder_write_sample_gt(const vcz_variant_encoder_t *self, size_t variant,
+    size_t sample, char *dest, size_t buflen, int64_t offset)
+{
+    const size_t ploidy = self->gt.num_columns;
+    size_t source_offset = variant * self->num_samples * ploidy + sample * ploidy;
+    const int32_t *source = ((int32_t *) self->gt.data) + source_offset;
+    const bool phased = self->gt_phased_data[variant * self->num_samples + sample];
+    int32_t value;
+    size_t ploid;
+    char sep = phased ? '|' : '/';
+
+    if (self->gt.item_size != 4) {
+        offset = VCZ_ERR_FIELD_UNSUPPORTED_TYPE;
+        goto out;
+    }
+
+    for (ploid = 0; ploid < ploidy; ploid++) {
+        value = source[ploid];
+        if (value != VCZ_INT_FILL) {
+            if (ploid > 0) {
+                dest[offset] = sep;
+                offset++;
+            }
+            if (value == VCZ_INT_MISSING) {
+                dest[offset] = '.';
+                offset++;
+            } else {
+                offset += vcz_itoa(value, dest + offset);
+                /* written = snprintf(value_buffer, sizeof(value_buffer), "%d", value);
+                 */
+                /* memcpy(dest + offset, value_buffer, written); */
+                /* offset += written; */
+            }
+        }
+    }
+    dest[offset] = '\t';
+    offset++;
+    dest[offset] = '\0';
+out:
+    return offset;
+}
+
+int64_t
+vcz_variant_encoder_write_format_fields(const vcz_variant_encoder_t *self,
+    size_t variant, size_t sample, char *dest, size_t buflen, int64_t offset)
+{
+    vcz_field_t field;
+    size_t j, row_size;
+    const void *data;
+
+    if (self->gt.data != NULL) {
+        offset = vcz_variant_encoder_write_sample_gt(
+            self, variant, sample, dest, buflen, offset);
+        if (offset < 0) {
+            goto out;
+        }
+    }
+
+    for (j = 0; j < self->num_format_fields; j++) {
+        field = self->format_fields[j];
+        dest[offset - 1] = ':';
+        row_size = self->num_samples * field.num_columns * field.item_size;
+        data = field.data + variant * row_size
+               + sample * field.num_columns * field.item_size;
+        offset = vcz_field_write_entry(&field, data, dest, buflen, offset);
+        if (offset < 0) {
+            goto out;
+        }
+    }
+out:
+    return offset;
+}
+
+int64_t
+vcz_variant_encoder_write_info_fields(const vcz_variant_encoder_t *self, size_t variant,
+    char *dest, size_t buflen, int64_t offset)
+{
+    vcz_field_t field;
+    size_t j;
+
+    if (self->num_info_fields == 0) {
+        dest[offset] = '.';
+        offset++;
+        dest[offset] = '\t';
+        offset++;
+    }
+    for (j = 0; j < self->num_info_fields; j++) {
+        if (j > 0) {
+            dest[offset - 1] = ';';
+        }
+        field = self->info_fields[j];
+        memcpy(dest + offset, field.name, field.name_length);
+        offset += field.name_length;
+        dest[offset] = '=';
+        offset++;
+        offset = vcz_field_write(&field, variant, dest, buflen, offset);
+        if (offset < 0) {
+            goto out;
+        }
+    }
+out:
+    return offset;
+}
+
+int64_t
+vcz_variant_encoder_write_row(
+    const vcz_variant_encoder_t *self, size_t row, char *buf, size_t buflen)
+{
+    int64_t offset = 0;
+    size_t j;
+
+    for (j = 0; j < VCZ_NUM_FIXED_FIELDS; j++) {
+        offset = vcz_field_write(&self->fixed_fields[j], row, buf, buflen, offset);
+        if (offset < 0) {
+            goto out;
+        }
+    }
+    offset = vcz_variant_encoder_write_info_fields(self, row, buf, buflen, offset);
+    if (offset < 0) {
+        goto out;
+    }
+    if (self->num_samples > 0) {
+        offset = vcz_variant_encoder_write_format_specifiers(self, buf, buflen, offset);
+        if (offset < 0) {
+            goto out;
+        }
+        for (j = 0; j < self->num_samples; j++) {
+            /* printf("Run sample %d\n", (int) j); */
+            offset = vcz_variant_encoder_write_format_fields(
+                self, row, j, buf, buflen, offset);
+            if (offset < 0) {
+                goto out;
+            }
+        }
+    }
+    offset--;
+    buf[offset] = '\0';
+out:
+    return offset;
+}
+
+void
+vcz_variant_encoder_print_state(const vcz_variant_encoder_t *self, FILE *out)
+{
+    size_t j;
+
+    fprintf(out, "vcz_variant_encoder: %p\n", (void *) self);
+    fprintf(out, "\tnum_samples: %d\n", (int) self->num_samples);
+    fprintf(out, "\tnum_variants: %d\n", (int) self->num_variants);
+    for (j = 0; j < VCZ_NUM_FIXED_FIELDS; j++) {
+        vcz_field_print_state(&self->fixed_fields[j], out);
+    }
+    fprintf(out, "\tINFO:\n");
+    for (j = 0; j < self->num_info_fields; j++) {
+        vcz_field_print_state(&self->info_fields[j], out);
+    }
+    fprintf(out, "\tFORMAT:\n");
+    if (self->gt.data != NULL) {
+        vcz_field_print_state(&self->gt, out);
+    }
+    for (j = 0; j < self->num_format_fields; j++) {
+        vcz_field_print_state(&self->format_fields[j], out);
+    }
+}
+
+static int
+vcz_variant_encoder_add_field(vcz_variant_encoder_t *self, vcz_field_t *field,
+    const char *name, int type, size_t item_size, size_t num_columns, const void *data)
+{
+    int ret = 0;
+
+    field->name_length = strlen(name);
+    if (field->name_length >= VCZ_MAX_FIELD_NAME_LEN) {
+        ret = VCZ_ERR_FIELD_NAME_TOO_LONG;
+        goto out;
+    }
+    strcpy(field->name, name);
+    field->type = type;
+    field->item_size = item_size;
+    field->num_columns = num_columns;
+    field->data = data;
+out:
+    return ret;
+}
+
+int
+vcz_variant_encoder_add_info_field(vcz_variant_encoder_t *self, const char *name,
+    int type, size_t item_size, size_t num_columns, const void *data)
+{
+    int ret = 0;
+    vcz_field_t *tmp, *field;
+
+    if (self->num_info_fields == self->max_info_fields) {
+        self->max_info_fields += self->field_array_size_increment;
+        tmp = realloc(
+            self->info_fields, self->max_info_fields * sizeof(*self->info_fields));
+        if (tmp == NULL) {
+            ret = VCZ_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->info_fields = tmp;
+    }
+    field = self->info_fields + self->num_info_fields;
+    self->num_info_fields++;
+    ret = vcz_variant_encoder_add_field(
+        self, field, name, type, item_size, num_columns, data);
+out:
+    return ret;
+}
+
+int
+vcz_variant_encoder_add_format_field(vcz_variant_encoder_t *self, const char *name,
+    int type, size_t item_size, size_t num_columns, const void *data)
+{
+    int ret = 0;
+    vcz_field_t *tmp, *field;
+
+    if (self->num_format_fields == self->max_format_fields) {
+        self->max_format_fields += self->field_array_size_increment;
+        /* NOTE: assuming realloc(NULL) is safe and portable. check */
+        tmp = realloc(
+            self->format_fields, self->max_format_fields * sizeof(*self->format_fields));
+        if (tmp == NULL) {
+            ret = VCZ_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->format_fields = tmp;
+    }
+    field = self->format_fields + self->num_format_fields;
+    self->num_format_fields++;
+
+    ret = vcz_variant_encoder_add_field(
+        self, field, name, type, item_size, num_columns, data);
+out:
+    return ret;
+}
+
+int
+vcz_variant_encoder_add_gt_field(vcz_variant_encoder_t *self, const void *gt_data,
+    size_t gt_item_size, size_t ploidy, const int8_t *gt_phased_data)
+{
+    strcpy(self->gt.name, "GT");
+    self->gt.item_size = gt_item_size;
+    self->gt.data = gt_data;
+    self->gt.num_columns = ploidy;
+    self->gt_phased_data = gt_phased_data;
+    return 0;
+}
+
+// clang-format off
+int
+vcz_variant_encoder_init(vcz_variant_encoder_t *self,
+    size_t num_samples, size_t num_variants,
+    const char *chrom_data, size_t chrom_item_size,
+    const int32_t *pos_data,
+    const char *id_data, size_t id_item_size, size_t id_num_columns,
+    const char *ref_data, size_t ref_item_size,
+    const char *alt_data, size_t alt_item_size, size_t alt_num_columns,
+    const int32_t *qual_data,
+    const char *filter_data, size_t filter_item_size, size_t filter_num_columns)
+
+{
+    vcz_field_t fixed_fields[] = {
+        { .name = "CHROM",
+            .type = VCZ_TYPE_STRING,
+            .item_size = chrom_item_size,
+            .num_columns = 1,
+            .data = chrom_data },
+        { .name = "POS",
+            .type = VCZ_TYPE_INT,
+            .item_size = 4,
+            .num_columns = 1,
+            .data = pos_data },
+        { .name = "ID",
+            .type = VCZ_TYPE_STRING,
+            .item_size = id_item_size,
+            .num_columns = id_num_columns,
+            .data = id_data },
+        { .name = "REF",
+            .type = VCZ_TYPE_STRING,
+            .item_size = ref_item_size,
+            .num_columns = 1,
+            .data = ref_data },
+        { .name = "ALT",
+            .type = VCZ_TYPE_STRING,
+            .item_size = alt_item_size,
+            .num_columns = alt_num_columns,
+            .data = alt_data },
+        { .name = "QUAL",
+            .type = VCZ_TYPE_INT,
+            .item_size = 4,
+            .num_columns = 1,
+            .data = qual_data },
+        { .name = "FILTER",
+            .type = VCZ_TYPE_STRING,
+            .item_size = filter_item_size,
+            .num_columns = filter_num_columns,
+            .data = filter_data } };
+
+    // clang-format on
+
+    memset(self, 0, sizeof(*self));
+    self->num_samples = num_samples;
+    self->num_variants = num_variants;
+    self->field_array_size_increment = 64;
+    memcpy(self->fixed_fields, fixed_fields, sizeof(fixed_fields));
+
+    return 0;
+}
+
+void
+vcz_variant_encoder_free(vcz_variant_encoder_t *self)
+{
+    if (self->info_fields != NULL) {
+        free(self->info_fields);
+        self->info_fields = NULL;
+    }
+    if (self->format_fields != NULL) {
+        free(self->format_fields);
+        self->format_fields = NULL;
+    }
+}

--- a/lib/vcf_encoder.h
+++ b/lib/vcf_encoder.h
@@ -1,0 +1,78 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#define VCZ_INT_MISSING -1
+#define VCZ_INT_FILL -2
+
+#define VCZ_NUM_FIXED_FIELDS 7
+
+#define VCZ_TYPE_INT 0
+#define VCZ_TYPE_FLOAT 0
+#define VCZ_TYPE_STRING 2
+
+// arbitrary - we can increase if needs be
+#define VCZ_MAX_FIELD_NAME_LEN 256
+
+#define VCZ_ERR_NO_MEMORY (-100)
+
+/* Built-in-limitations */
+#define VCZ_ERR_FIELD_NAME_TOO_LONG (-201)
+#define VCZ_ERR_FIELD_UNSUPPORTED_TYPE (-202)
+
+typedef struct {
+    char name[VCZ_MAX_FIELD_NAME_LEN];
+    size_t name_length;
+    int type;
+    size_t item_size;
+    size_t num_columns;
+    const void *data;
+} vcz_field_t;
+
+int64_t vcz_field_write(
+    const vcz_field_t *self, size_t row, char *buf, size_t buflen, int64_t offset);
+void vcz_field_print_state(const vcz_field_t *self, FILE *out);
+
+typedef struct {
+    size_t num_variants;
+    size_t num_samples;
+    vcz_field_t fixed_fields[VCZ_NUM_FIXED_FIELDS];
+    vcz_field_t gt;
+    size_t num_info_fields;
+    size_t max_info_fields;
+    vcz_field_t *info_fields;
+    const int8_t *gt_phased_data;
+    size_t num_format_fields;
+    size_t max_format_fields;
+    size_t field_array_size_increment;
+    vcz_field_t *format_fields;
+} vcz_variant_encoder_t;
+
+// clang-format off
+int vcz_variant_encoder_init(vcz_variant_encoder_t *self,
+    size_t num_variants, size_t num_samples,
+    const char *contig_data, size_t contig_item_size,
+    const int32_t *position_data,
+    const char *id_data, size_t id_item_size, size_t id_num_columns,
+    const char *ref_data, size_t ref_item_size,
+    const char *alt_data, size_t alt_item_size, size_t alt_num_columns,
+    const int32_t *qual_data, const char *filter_data, size_t filter_item_size,
+    size_t filter_num_columns
+);
+// clang-format on
+
+void vcz_variant_encoder_free(vcz_variant_encoder_t *self);
+void vcz_variant_encoder_print_state(const vcz_variant_encoder_t *self, FILE *out);
+int vcz_variant_encoder_add_gt_field(vcz_variant_encoder_t *self,
+    const void *gt_data, size_t gt_item_size, size_t ploidy,
+    const int8_t *gt_phased_data);
+int vcz_variant_encoder_add_format_field(vcz_variant_encoder_t *self,
+    const char *name, int type,
+    size_t item_size, size_t num_columns, const void *data);
+int vcz_variant_encoder_add_info_field(vcz_variant_encoder_t *self,
+    const char *name, int type,
+    size_t item_size, size_t num_columns, const void *data);
+int64_t vcz_variant_encoder_write_row(
+    const vcz_variant_encoder_t *self, size_t row, char *buf, size_t buflen);
+
+int vcz_itoa(int32_t v, char *out);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=45", "wheel", "numpy>=2"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vcztools"
+version = "0.0.1"
+dependencies = [
+    "numpy>=1.23.5",
+]
+requires-python = ">=3.9"
+
+[project.scripts]
+vcztools = "vcztools.__main__:main"
+
+[tool.setuptools]
+packages = ["vcztools"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+import numpy
+from setuptools import Extension
+from setuptools import setup
+
+_vcztools_module = Extension(
+    "_vcztools",
+    sources=["_vcztoolsmodule.c", "lib/vcf_encoder.c"],
+    extra_compile_args=["-std=c99"],
+    include_dirs=["lib", numpy.get_include()],
+)
+
+setup(
+    ext_modules=[_vcztools_module],
+)


### PR DESCRIPTION
This is a partially working prototype doing the VCF encoding in C, via the Python C API. While it looks like a lot of boilerplate, I'm following some well established patterns used in other projects which have proved to be very stable and low maintenance. Thus, while it is quite a bit of work to get C extensions like this built in the first place, once they're done, they are done and almost never need any changes. Building binaries for PyPI/conda-forge for something like this which has no external dependencies is also quite routine now. (C extensions are *terrible* for projects that expect lots of contributions from other developers, and the overhead there is education largely. Here, though, I would not imagine this part of the code to change very much over time, as we'll architect things so that all the complex filtering logic is done in Python and just the VCF encoding aspect is done in C.)

The motivation for doing this is two-fold:

1. Performance. We must be able to generate VCF text fast enough so that we are not a bottleneck in existing pipelines. Some brief profiling on VCFs with lots of fields indicated that the current numba version indicates that performance is a long way below this threshold. Since we are not doing something that numba is particularly suited for, I think it's simpler to just invest in a C implementation now.
2. Ongoing maintenance/user experience. Numba has its own issues, and is moving quickly. As I said above, experience has shown that a well-targeted Python-C module has substantially less ongoing maintenance costs than numba-based packages.

Some brief profiling for reference (based on first chunk of 10K variants)

## Small simulated GT-only file 10 samples
```
jk@holly$ time python3 -m vcztools view ~/large_files/sgkit-publication-scaling/chr21_10_1.zarr | pv > /dev/null 
 702KiB 0:00:07 [88.8KiB/s] [     <=>                                                                                ]

real    0m7.918s
user    0m10.102s
sys     0m5.338s

jk@holly$ time python3 dev.py ~/large_files/sgkit-publication-scaling/chr21_10_1.zarr | pv > /dev/null 
 810KiB 0:00:00 [1.24MiB/s] [ <=>                                                                                    ]

real    0m0.643s
user    0m1.582s
sys     0m2.850s
```
Here the time is dominated by the numba-lag. The C extension gets to work immediately.

## Larger simulated GT-only file 10^5 samples
```
$ time python3 -m vcztools view ~/large_files/sgkit-publication-scaling/chr21_10_5.zarr | pv > /dev/null 
3.73GiB 0:00:37 [ 102MiB/s] [                                                                                                                           <=>                                                                                  ]

real    0m37.179s
user    0m38.722s
sys     0m8.322s

(Throughput peaks at 150MiB/s)
```

```
3.73GiB 0:00:35 [ 106MiB/s] [                                                                                                                               <=>                                                                              ]

real    0m35.803s
user    0m34.361s
sys     0m10.436s

(Throughput peaks at around 140MiB/s)
```

## 1000G 2020 Chromosome 2

```
$ time python3 -m vcztools view ~/large_files/tmp/1kg_chr2_2.zarr/ | pv > /dev/null 
 915MiB 0:08:07 [1.88MiB/s] [                                                                                                                                                                                                        <=>     ]

real    8m7.353s
user    8m7.111s
sys     0m11.802s

(Peak throughput around 2MiB/s, mostly hovering at less than 1MiB/s)

$ time python3 dev.py ~/large_files/tmp/1kg_chr2_2.zarr/ | pv > /dev/null 
1.16GiB 0:00:35 [33.6MiB/s] [                                                                         <=>                                                                                                                                    ]

real    0m35.200s
user    0m32.345s
sys     0m10.605s

(Peak throughput around 70MiB/s)
```
(Note the difference in the volume of data produced here is because the C code is just listing all FORMAT fields, even if they only contain missing data currently).

It was this last benchmark that motivated me to do the C version, and I think makes it worth the initial effort to build it. While there's still a lot of work to be done (it's completely unsafe currently, e.g.) it's something I can chip away at, and I'm sure we can improve perf further if needs be. I think we'd have to work harder to bring the numba version up to acceptable speed.

cc @tomwhite 

