### PR TITLE
Add basic support for '--targets/-t'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "numba",
   "zarr>=2.17,<3",
   "click",
+  "pyranges",
 ]
 requires-python = ">=3.9"
 dynamic = ["version"]

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -6,6 +6,9 @@ from vcztools.regions import parse_targets_string
 @pytest.mark.parametrize(
     "targets, expected",
     [
+        ("chr1", ("chr1", None, None)),
+        ("chr1:12", ("chr1", 12, 12)),
+        ("chr1:12-", ("chr1", 12, None)),
         ("chr1:12-103", ("chr1", 12, 103)),
     ],
 )

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -1,0 +1,15 @@
+from typing import Optional
+import pytest
+from vcztools.regions import parse_targets_string
+
+
+@pytest.mark.parametrize(
+    "targets, expected",
+    [
+        ("chr1:12-103", ("chr1", 12, 103)),
+    ],
+)
+def test_parse_targets_string(
+    targets: str, expected: tuple[str, Optional[int], Optional[int]]
+):
+    assert parse_targets_string(targets) == expected

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -1,6 +1,6 @@
 from typing import Optional
 import pytest
-from vcztools.regions import parse_targets_string
+from vcztools.regions import parse_region
 
 
 @pytest.mark.parametrize(
@@ -12,7 +12,7 @@ from vcztools.regions import parse_targets_string
         ("chr1:12-103", ("chr1", 12, 103)),
     ],
 )
-def test_parse_targets_string(
+def test_parse_region(
     targets: str, expected: tuple[str, Optional[int], Optional[int]]
 ):
-    assert parse_targets_string(targets) == expected
+    assert parse_region(targets) == expected

--- a/tests/test_vcf_writer.py
+++ b/tests/test_vcf_writer.py
@@ -55,6 +55,27 @@ def test_write_vcf(shared_datadir, tmp_path, output_is_path, implementation):
     assert_vcfs_close(path, output)
 
 
+@pytest.mark.parametrize("implementation", ["c"])
+def test_write_vcf__targets(shared_datadir, tmp_path, implementation):
+    path = shared_datadir / "vcf" / "sample.vcf.gz"
+    intermediate_icf = tmp_path.joinpath("intermediate.icf")
+    intermediate_vcz = tmp_path.joinpath("intermediate.vcz")
+    output = tmp_path.joinpath("output.vcf")
+
+    vcf2zarr.convert(
+        [path], intermediate_vcz, icf_path=intermediate_icf, worker_processes=0
+    )
+
+    write_vcf(intermediate_vcz, output, variant_targets="20", implementation=implementation)
+
+    v = VCF(output)
+
+    assert v.samples == ["NA00001", "NA00002", "NA00003"]
+
+    for variant in v:
+        assert variant.CHROM == "20"
+
+
 def test_write_vcf__set_header(shared_datadir, tmp_path):
     path = shared_datadir / "vcf" / "sample.vcf.gz"
     intermediate_icf = tmp_path.joinpath("intermediate.icf")

--- a/tests/test_vcf_writer.py
+++ b/tests/test_vcf_writer.py
@@ -55,7 +55,7 @@ def test_write_vcf(shared_datadir, tmp_path, output_is_path, implementation):
     assert_vcfs_close(path, output)
 
 
-@pytest.mark.parametrize("implementation", ["c"])
+@pytest.mark.parametrize("implementation", ["c", "numba"])
 def test_write_vcf__targets(shared_datadir, tmp_path, implementation):
     path = shared_datadir / "vcf" / "sample.vcf.gz"
     intermediate_icf = tmp_path.joinpath("intermediate.icf")
@@ -72,8 +72,12 @@ def test_write_vcf__targets(shared_datadir, tmp_path, implementation):
 
     assert v.samples == ["NA00001", "NA00002", "NA00003"]
 
+    count = 0
     for variant in v:
         assert variant.CHROM == "20"
+        count += 1
+
+    assert count == 6
 
 
 def test_write_vcf__set_header(shared_datadir, tmp_path):

--- a/vcztools/cli.py
+++ b/vcztools/cli.py
@@ -18,9 +18,16 @@ class NaturalOrderGroup(click.Group):
 @click.command
 @click.argument("path", type=click.Path())
 @click.option("-c", is_flag=True, default=False, help="Use C implementation")
-def view(path, c):
+@click.option(
+    "-t",
+    "--targets",
+    type=str,
+    default=None,
+    help="Target regions to include.",
+)
+def view(path, c, targets):
     implementation = "c" if c else "numba"
-    vcf_writer.write_vcf(path, sys.stdout, implementation=implementation)
+    vcf_writer.write_vcf(path, sys.stdout, variant_targets=targets, implementation=implementation)
 
 
 @click.group(cls=NaturalOrderGroup, name="vcztools")

--- a/vcztools/regions.py
+++ b/vcztools/regions.py
@@ -9,8 +9,13 @@ def parse_targets_string(targets: str) -> tuple[str, Optional[int], Optional[int
     if re.search(r":\d+-\d*$", targets):
         contig, start_end = targets.rsplit(":", 1)
         start, end = start_end.split("-")
-        return contig, int(start), int(end)
-    raise NotImplementedError()
+        return contig, int(start), int(end) if len(end) > 0 else None
+    elif re.search(r":\d+$", targets):
+        contig, start = targets.rsplit(":", 1)
+        return contig, int(start), int(start)
+    else:
+        contig = targets
+        return contig, None, None
 
 
 def pslice_to_slice(
@@ -29,6 +34,7 @@ def pslice_to_slice(
     else:
         contig_pos = variant_position[slice(contig_range[0], contig_range[1])]
         if start is None:
+            assert end is not None  # covered by case above
             start_index = contig_range[0]
             end_index = contig_range[0] + np.searchsorted(contig_pos, [end])[0]
         elif end is None:

--- a/vcztools/regions.py
+++ b/vcztools/regions.py
@@ -1,0 +1,42 @@
+import re
+from typing import Any, List, Optional
+
+import numpy as np
+
+
+def parse_targets_string(targets: str) -> tuple[str, Optional[int], Optional[int]]:
+    """Return the contig, start position and end position from a targets string."""
+    if re.search(r":\d+-\d*$", targets):
+        contig, start_end = targets.rsplit(":", 1)
+        start, end = start_end.split("-")
+        return contig, int(start), int(end)
+    raise NotImplementedError()
+
+
+def pslice_to_slice(
+    all_contigs: List[str],
+    variant_contig: Any,
+    variant_position: Any,
+    contig: str,
+    start: Optional[int] = None,
+    end: Optional[int] = None,
+) -> slice:
+    contig_index = all_contigs.index(contig)
+    contig_range = np.searchsorted(variant_contig, [contig_index, contig_index + 1])
+
+    if start is None and end is None:
+        start_index, end_index = contig_range
+    else:
+        contig_pos = variant_position[slice(contig_range[0], contig_range[1])]
+        if start is None:
+            start_index = contig_range[0]
+            end_index = contig_range[0] + np.searchsorted(contig_pos, [end])[0]
+        elif end is None:
+            start_index = contig_range[0] + np.searchsorted(contig_pos, [start])[0]
+            end_index = contig_range[1]
+        else:
+            start_index, end_index = contig_range[0] + np.searchsorted(
+                contig_pos, [start, end]
+            )
+
+    return slice(start_index, end_index)

--- a/vcztools/regions.py
+++ b/vcztools/regions.py
@@ -18,7 +18,7 @@ def parse_targets_string(targets: str) -> tuple[str, Optional[int], Optional[int
         return contig, None, None
 
 
-def pslice_to_slice(
+def region_to_slice(
     all_contigs: List[str],
     variant_contig: Any,
     variant_position: Any,
@@ -26,6 +26,12 @@ def pslice_to_slice(
     start: Optional[int] = None,
     end: Optional[int] = None,
 ) -> slice:
+    """Convert a VCF region to a Python slice."""
+
+    # subtract one from start since VCF is 1-based (fully closed),
+    # but Python slices are 0-based (half open)
+    start = None if start is None else start - 1
+
     contig_index = all_contigs.index(contig)
     contig_range = np.searchsorted(variant_contig, [contig_index, contig_index + 1])
 

--- a/vcztools/vcf_writer.py
+++ b/vcztools/vcf_writer.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import MutableMapping, Optional, TextIO, Union
 
 import numpy as np
-from vcztools.regions import parse_targets_string, region_to_slice
+from vcztools.regions import parse_targets, regions_to_selection
 import zarr
 
 from . import _vcztools
@@ -167,17 +167,15 @@ def write_vcf(
         if variant_targets is None:
             variant_mask = np.ones(pos.shape[0], dtype=bool)
         else:
-            contig, start, end = parse_targets_string(variant_targets)
-            variant_slice = region_to_slice(
+            regions = parse_targets(variant_targets)
+            variant_selection = regions_to_selection(
                 root["contig_id"][:].astype("U").tolist(),
                 root["variant_contig"],
-                pos,
-                contig,
-                start,
-                end,
+                pos[:],
+                regions,
             )
             variant_mask = np.zeros(pos.shape[0], dtype=bool)
-            variant_mask[variant_slice] = 1
+            variant_mask[variant_selection] = 1
         # Use zarr arrays to get mask chunks aligned with the main data
         # for convenience.
         z_variant_mask = zarr.array(variant_mask, chunks=pos.chunks[0])

--- a/vcztools/vcf_writer.py
+++ b/vcztools/vcf_writer.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import MutableMapping, Optional, TextIO, Union
 
 import numpy as np
-from vcztools.regions import parse_targets_string, pslice_to_slice
+from vcztools.regions import parse_targets_string, region_to_slice
 import zarr
 
 from . import _vcztools
@@ -168,7 +168,14 @@ def write_vcf(
             variant_mask = np.ones(pos.shape[0], dtype=bool)
         else:
             contig, start, end = parse_targets_string(variant_targets)
-            variant_slice = pslice_to_slice(root["contig_id"][:].astype("U").tolist(), root["variant_contig"], pos, contig, start, end)
+            variant_slice = region_to_slice(
+                root["contig_id"][:].astype("U").tolist(),
+                root["variant_contig"],
+                pos,
+                contig,
+                start,
+                end,
+            )
             variant_mask = np.zeros(pos.shape[0], dtype=bool)
             variant_mask[variant_slice] = 1
         # Use zarr arrays to get mask chunks aligned with the main data

--- a/vcztools/vcf_writer.py
+++ b/vcztools/vcf_writer.py
@@ -188,6 +188,7 @@ def write_vcf(
                 numba_chunk_to_vcf(
                     root,
                     v_chunk,
+                    v_mask_chunk,
                     header_info_fields,
                     header_format_fields,
                     contigs,
@@ -296,16 +297,16 @@ def c_chunk_to_vcf(root, v_chunk, v_mask_chunk, contigs, filters, output):
 
 
 def numba_chunk_to_vcf(
-    root, v_chunk, header_info_fields, header_format_fields, contigs, filters, output
+    root, v_chunk, v_mask_chunk, header_info_fields, header_format_fields, contigs, filters, output
 ):
     # fixed fields
 
-    chrom = root.variant_contig.blocks[v_chunk]
-    pos = root.variant_position.blocks[v_chunk]
-    id = root.variant_id.blocks[v_chunk].astype("S")
-    alleles = root.variant_allele.blocks[v_chunk].astype("S")
-    qual = root.variant_quality.blocks[v_chunk]
-    filter_ = root.variant_filter.blocks[v_chunk]
+    chrom = get_block_selection(root.variant_contig, v_chunk, v_mask_chunk)
+    pos = get_block_selection(root.variant_position, v_chunk, v_mask_chunk)
+    id = get_block_selection(root.variant_id, v_chunk, v_mask_chunk).astype("S")
+    alleles = get_block_selection(root.variant_allele, v_chunk, v_mask_chunk).astype("S")
+    qual = get_block_selection(root.variant_quality, v_chunk, v_mask_chunk)
+    filter_ = get_block_selection(root.variant_filter, v_chunk, v_mask_chunk)
 
     n_variants = len(pos)
 
@@ -327,7 +328,7 @@ def numba_chunk_to_vcf(
             # not the other way around. This is probably not what we want to
             # do, but keeping it this way to preserve tests initially.
             continue
-        values = arr.blocks[v_chunk]
+        values = get_block_selection(arr, v_chunk, v_mask_chunk)
         if arr.dtype == bool:
             info_mask[k] = create_mask(values)
             info_bufs.append(np.zeros(0, dtype=np.uint8))
@@ -366,7 +367,7 @@ def numba_chunk_to_vcf(
         var = "call_genotype" if key == "GT" else f"call_{key}"
         if var not in root:
             continue
-        values = root[var].blocks[v_chunk]
+        values = get_block_selection(root[var], v_chunk, v_mask_chunk)
         if key == "GT":
             n_samples = values.shape[1]
             format_mask[k] = create_mask(values)
@@ -394,7 +395,7 @@ def numba_chunk_to_vcf(
     format_indexes = np.empty((len(format_values), n_samples + 1), dtype=np.int32)
 
     if "call_genotype_phased" in root:
-        call_genotype_phased = root["call_genotype_phased"].blocks[v_chunk][:]
+        call_genotype_phased = get_block_selection(root["call_genotype_phased"], v_chunk, v_mask_chunk)[:]
     else:
         call_genotype_phased = np.full((n_variants, n_samples), False, dtype=bool)
 


### PR DESCRIPTION
Fixes #16

This is just a quick draft, but I wanted to share early for visibility.

* It uses a variant mask, since we will need one anyway for overlap queries. (Some of the code is inspired by https://github.com/sgkit-dev/vcf-zarr-publication/blob/52428c97822a35a7c29f150f35ec6bd7a29dad37/src/zarr_afdist.py)
* I haven't thought about efficiency. The most glaring is that chunks that are masked out are not skipped - perhaps that should be done here. The linked issues in #16 could be looked at later.
* It only handles a very limited part of the `-t` syntax - still needs to handle missing start/end, multiple targets, and the ^ syntax (for exclude).
* I only implemented it for the C implementation branch. It would be easy enough to add for Numba, but perhaps we could drop that branch soon if the C branch has feature parity now?
* It needs tests and perhaps a bit more doc.
* We should add linting to the repo.
