### PR TITLE
Add support for -s/--samples

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+import pytest
+from numpy.testing import assert_array_equal
+
+from vcztools.utils import search
+
+
+@pytest.mark.parametrize(
+    ("a", "v", "expected_ind"),
+    [
+        (["a", "b", "c", "d"], ["b", "a", "c"], [1, 0, 2]),
+        (["a", "c", "d", "b"], ["b", "a", "c"], [3, 0, 1]),
+        (["a", "c", "d", "b"], ["b", "a", "a", "c"], [3, 0, 0, 1]),
+        (["a", "c", "d", "b"], [], []),
+    ],
+)
+def test_search(a, v, expected_ind):
+    assert_array_equal(search(a, v), expected_ind)

--- a/vcztools/cli.py
+++ b/vcztools/cli.py
@@ -30,15 +30,26 @@ def index(path):
     help="Regions to include.",
 )
 @click.option(
+    "-s",
+    "--samples",
+    type=str,
+    default=None,
+    help="Samples to include.",
+)
+@click.option(
     "-t",
     "--targets",
     type=str,
     default=None,
     help="Target regions to include.",
 )
-def view(path, regions, targets):
+def view(path, regions, targets, samples):
     vcf_writer.write_vcf(
-        path, sys.stdout, variant_regions=regions, variant_targets=targets
+        path,
+        sys.stdout,
+        variant_regions=regions,
+        variant_targets=targets,
+        samples=samples,
     )
 
 

--- a/vcztools/utils.py
+++ b/vcztools/utils.py
@@ -1,0 +1,8 @@
+import numpy as np
+
+
+def search(a, v):
+    """Like `np.searchsorted`, but array `a` does not have to be sorted."""
+    sorter = np.argsort(a)
+    rank = np.searchsorted(a, v, sorter=sorter)
+    return sorter[rank]

--- a/vcztools/vcf_writer.py
+++ b/vcztools/vcf_writer.py
@@ -223,11 +223,14 @@ def write_vcf(
                     )
 
 
-def get_block_selection(zarray, key, mask):
-    if mask is None:
-        return zarray.blocks[key]
-    else:
-        return zarray.blocks[key][mask]
+def get_block_selection(zarray, v_chunk, mask):
+    v_chunksize = zarray.chunks[0]
+    start = v_chunksize * v_chunk
+    end = v_chunksize * (v_chunk + 1)
+    result = zarray[start:end]
+    if mask is not None:
+        result = result[mask]
+    return result
 
 
 def c_chunk_to_vcf(root, v_chunk, v_mask_chunk, contigs, filters, output):


### PR DESCRIPTION
This uses Zarr indexing to subset by samples - which ensures that only the relevant chunks are loaded.

Zarr also supports out-of-order indexing, which makes it straightforward to support the bcftools feature where the sample output order is the one specified by `--samples`.