### PR TITLE
bcftools validation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
   python_test:
     name: Python tests
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -el {0}
     strategy:
       matrix:
         # Use macos-13 because pip binary packages for ARM aren't
@@ -37,12 +40,15 @@ jobs:
             python-version: "3.10"
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Set up Miniconda with Python ${{ matrix.python-version }}
+        uses: conda-incubator/setup-miniconda@v3
         with:
+          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+          channels: conda-forge,bioconda
       - name: Install dependencies
         run: |
+          conda install bcftools
           python -m pip install --upgrade pip
           python -m pip install '.[dev]'
           # Build the extension module in-place so pytest can find it

--- a/tests/test_bcftools_validation.py
+++ b/tests/test_bcftools_validation.py
@@ -1,0 +1,54 @@
+import pathlib
+import subprocess
+
+import click.testing as ct
+import pytest
+
+import vcztools.cli as cli
+
+from .utils import assert_vcfs_close, vcz_path_cache
+
+
+def run_bcftools(args: str) -> str:
+    """Run bcftools (which must be on the PATH) and return stdout as a string."""
+    completed = subprocess.run(
+        ["bcftools", *(args.split(" "))], capture_output=True, check=True
+    )
+    return completed.stdout.decode("utf-8")
+
+
+def run_vcztools(args: str) -> str:
+    """Run run_vcztools and return stdout as a string."""
+    runner = ct.CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli.vcztools_main,
+        args,
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    return result.stdout
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    ("args", "vcf_file"),
+    [
+        ("view --no-version", "sample.vcf.gz"),
+    ]
+)
+# fmt: on
+def test(tmp_path, args, vcf_file):
+    original = pathlib.Path("tests/data/vcf") / vcf_file
+    vcz = vcz_path_cache(original)
+
+    bcftools_out = run_bcftools(f"{args} {original}")
+    bcftools_out_file = tmp_path.joinpath("bcftools_out.vcf")
+    with open(bcftools_out_file, "w") as f:
+        f.write(bcftools_out)
+
+    vcztools_out = run_vcztools(f"{args} {vcz}")
+    vcztools_out_file = tmp_path.joinpath("vcztools_out.vcf")
+    with open(vcztools_out_file, "w") as f:
+        f.write(vcztools_out)
+
+    assert_vcfs_close(bcftools_out_file, vcztools_out_file)

--- a/vcztools/cli.py
+++ b/vcztools/cli.py
@@ -23,6 +23,11 @@ def index(path):
 @click.command
 @click.argument("path", type=click.Path())
 @click.option(
+    "--no-version",
+    is_flag=True,
+    help="Do not append version and command line information to the output VCF header.",
+)
+@click.option(
     "-r",
     "--regions",
     type=str,
@@ -43,7 +48,7 @@ def index(path):
     default=None,
     help="Target regions to include.",
 )
-def view(path, regions, targets, samples):
+def view(path, no_version, regions, targets, samples):
     vcf_writer.write_vcf(
         path,
         sys.stdout,


### PR DESCRIPTION
Fixes #23 

This is on top of #40. CI will fail since it assumes the `bcftools` binary is on the path (need to figure out the best way to install it).